### PR TITLE
render: include shader str into binary

### DIFF
--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -8,11 +8,7 @@ pub struct Material {
     program: u32,
 }
 
-pub fn create_shader(gl: &gl::Gl, name: &Path, shader_type: gl::types::GLenum) -> u32 {
-    let mut file = File::open(name).unwrap();
-    let mut content = String::new();
-    file.read_to_string(&mut content).unwrap();
-
+pub fn create_shader(gl: &gl::Gl, content: &str, shader_type: gl::types::GLenum) -> u32 {
     let length = content.len() as i32;
 
     let vs;
@@ -37,8 +33,8 @@ pub fn create_shader(gl: &gl::Gl, name: &Path, shader_type: gl::types::GLenum) -
 
 impl Material {
     pub fn new(gl: &gl::Gl, vs: &str, fs: &str) -> Self {
-        let vs = create_shader(gl, Path::new(vs), gl::VERTEX_SHADER);
-        let fs = create_shader(gl, Path::new(fs), gl::FRAGMENT_SHADER);
+        let vs = create_shader(gl, vs, gl::VERTEX_SHADER);
+        let fs = create_shader(gl, fs, gl::FRAGMENT_SHADER);
 
         let program = unsafe { gl.CreateProgram() };
         unsafe {

--- a/src/render/sector.rs
+++ b/src/render/sector.rs
@@ -27,9 +27,12 @@ impl<T: BaseNum> ToArr for Matrix4<T> {
     }
 }
 
+const WALL_FRAG_STR: &str = include_str!("wall.frag");
+const WALL_VERT_STR: &str = include_str!("wall.vert");
+
 impl SectorModel {
     pub fn new(gl: &gl::Gl, ibuffer: Vec<u16>, texture: u32) -> Self {
-        let wall_material = Material::new(gl, "./src/render/wall.vert", "./src/render/wall.frag");
+        let wall_material = Material::new(gl, WALL_VERT_STR, WALL_FRAG_STR);
 
         let mut ib = unsafe { std::mem::zeroed() };
         let pos_att = wall_material.get_attrib_location(gl, "position\0");


### PR DESCRIPTION
Include shader text into binary avoid to have to distribute it separatly.
And this avoid to have to manage file access and eventual errors.